### PR TITLE
Add /api endpoint alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
+# RAG Query API
 
+This project exposes a simple FastAPI application used to query a small knowledge base.
+
+## Endpoints
+
+- `POST /query` – main endpoint for asking questions.
+- `POST /api` – alias for `/query` (useful when clients expect `/api`).
+- `GET /health` – returns the state of the database and whether the API key is set.
+
+Requests are handled by `app.py` and the service reads from `knowledge_base.db`.
+Make sure to populate the database using `preprocess.py` before querying.

--- a/app.py
+++ b/app.py
@@ -684,6 +684,11 @@ async def query_knowledge_base(request: QueryRequest):
             content={"error": error_msg}
         )
 
+# Provide /api as a convenience alias for /query
+@app.post("/api")
+async def api_alias(request: QueryRequest):
+    return await query_knowledge_base(request)
+
 # Health check endpoint
 @app.get("/health")
 async def health_check():


### PR DESCRIPTION
## Summary
- add `/api` as an alias for the `/query` endpoint
- document available endpoints in README

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684530679bac83218aedfcf67760eac4