### PR TITLE
Document Git LFS process for large knowledge_base.db

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+large_files/knowledge_base.db filter=lfs diff=lfs merge=lfs -text

--- a/README.md
+++ b/README.md
@@ -11,3 +11,4 @@ This project exposes a simple FastAPI application used to query a small knowledg
 
 Requests are handled by `app.py` and the service reads from `knowledge_base.db`.
 Make sure to populate the database using `preprocess.py` before querying.
+If your knowledge_base.db exceeds GitHub's 25 MB upload limit, see large_files/README.md for using Git LFS.

--- a/large_files/PLACEHOLDER.txt
+++ b/large_files/PLACEHOLDER.txt
@@ -1,0 +1,3 @@
+This file acts as a placeholder for the 80 MB knowledge_base.db requested by the user.
+Due to environment limitations, large files cannot be uploaded directly. Please
+replace this file with your actual large file using Git LFS or manual upload.

--- a/large_files/README.md
+++ b/large_files/README.md
@@ -1,0 +1,11 @@
+This directory contains placeholders for large files that exceed the 4MB size limit of the Codex environment. For example, the "80 MB" `knowledge_base.db` cannot be uploaded directly.
+
+GitHub's web interface only allows files up to 25 MB. To include bigger files, you must use Git LFS (Large File Storage).
+
+Steps to add `knowledge_base.db` using Git LFS:
+1. Install Git LFS if you haven't already: `git lfs install`
+2. Track the file path: `git lfs track "large_files/knowledge_base.db"`
+3. Add the file and `.gitattributes`: `git add .gitattributes large_files/knowledge_base.db`
+4. Commit and push as usual.
+
+After pushing, the real file will be stored using Git LFS, while your repository only contains a small pointer file.

--- a/large_files/knowledge_base.db.placeholder
+++ b/large_files/knowledge_base.db.placeholder
@@ -1,0 +1,1 @@
+This placeholder represents the 80 MB knowledge_base.db file. Use Git LFS to upload the actual file.


### PR DESCRIPTION
## Summary
- add `.gitattributes` tracking `knowledge_base.db`
- update `large_files/README.md` with Git LFS instructions
- tweak placeholder text to reference the 80 MB database
- add `knowledge_base.db.placeholder`
- mention Git LFS instructions in root README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684ac8eb7e848321bc271f7209e4faf1