### PR TITLE
Clarify LFS placeholders

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+knowledge_base.db filter=lfs diff=lfs merge=lfs -text

--- a/README.md
+++ b/README.md
@@ -11,3 +11,4 @@ This project exposes a simple FastAPI application used to query a small knowledg
 
 Requests are handled by `app.py` and the service reads from `knowledge_base.db`.
 Make sure to populate the database using `preprocess.py` before querying.
+If your knowledge_base.db exceeds GitHub's 25 MB upload limit, see large_files/README.md for using Git LFS.

--- a/large_files/PLACEHOLDER.txt
+++ b/large_files/PLACEHOLDER.txt
@@ -1,0 +1,3 @@
+This file acts as a placeholder for the 75 MB knowledge_base.db requested by the user.
+Due to environment limitations, large files cannot be uploaded directly.
+Place the real 'knowledge_base.db' in the repository root and track it with Git LFS.

--- a/large_files/README.md
+++ b/large_files/README.md
@@ -1,0 +1,21 @@
+This directory contains placeholders for large files that exceed the 4MB size limit of the Codex environment. For example, the "75 MB" `knowledge_base.db` cannot be uploaded directly.
+
+GitHub's web interface only allows files up to 25 MB. To include bigger files, you must use Git LFS (Large File Storage).
+
+Steps to add `knowledge_base.db` using Git LFS:
+1. Install Git LFS if you haven't already: `git lfs install`
+2. Track the file path: `git lfs track "knowledge_base.db"`
+3. Add the file and `.gitattributes`: `git add .gitattributes knowledge_base.db`
+4. Commit and push as usual.
+
+After pushing, the real file will be stored using Git LFS, while your repository only contains a small pointer file.
+
+## Resolving merge conflicts
+If you pull updates and see a conflict in `.gitattributes`, both sides likely added a line for `knowledge_base.db`.
+Open the file and keep the path you actually use (e.g. `knowledge_base.db`). Remove the conflict markers, then run:
+
+```bash
+git add .gitattributes
+git commit
+```
+This completes the merge so you can push your LFS object normally.

--- a/large_files/knowledge_base.db.placeholder
+++ b/large_files/knowledge_base.db.placeholder
@@ -1,0 +1,2 @@
+This placeholder represents the 75 MB knowledge_base.db file.
+Upload the real file to the repository root using Git LFS.


### PR DESCRIPTION
## Summary
- clarify that the example database is 75 MB
- keep instructions for tracking `knowledge_base.db` with Git LFS

## Testing
- `python -m py_compile app.py preprocess.py`


------
https://chatgpt.com/codex/tasks/task_e_684ac8eb7e848321bc271f7209e4faf1